### PR TITLE
DEV-872 Group open registration meetings by parent conference with agenda-prefix color coding

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -533,3 +533,141 @@ line-height: 16px;
 .pointer{
   cursor:pointer;
 }
+
+
+
+.CBD {
+  color: #fff;
+  background: #009B48;
+}
+
+.CP {
+  color: #fff;
+  background: #A05800;
+}
+
+.NP {
+  color: #fff;
+  background: #0086B7;
+}
+
+.SBI{
+  color: #fff;
+  background: #5C6BC0;
+}
+.SBSTTA{
+  color: #fff;
+  background: #00838F;
+}
+
+/* Panel variants by agenda prefix */
+.panel-cbd {
+  border-color: #009B48;
+}
+.panel-cbd > .panel-heading {
+  color: #fff;
+  background-color: #009B48;
+  border-color: #008a40;
+}
+.panel-cbd > .panel-footer {
+  border-color: #009B48;
+}
+
+.panel-cp {
+  border-color: #A05800;
+}
+.panel-cp > .panel-heading {
+  color: #fff;
+  background-color: #A05800;
+  border-color: #8a4c00;
+}
+.panel-cp > .panel-footer {
+  border-color: #A05800;
+}
+
+.panel-np {
+  border-color: #0086B7;
+}
+.panel-np > .panel-heading {
+  color: #fff;
+  background-color: #0086B7;
+  border-color: #0074a0;
+}
+.panel-np > .panel-footer {
+  border-color: #0086B7;
+}
+
+.panel-sbi {
+  border-color: #5C6BC0;
+}
+.panel-sbi > .panel-heading {
+  color: #fff;
+  background-color: #5C6BC0;
+  border-color: #4a5ab0;
+}
+.panel-sbi > .panel-footer {
+  border-color: #5C6BC0;
+}
+
+.panel-sbstta {
+  border-color: #00838F;
+}
+.panel-sbstta > .panel-heading {
+  color: #fff;
+  background-color: #00838F;
+  border-color: #00727c;
+}
+.panel-sbstta > .panel-footer {
+  border-color: #00838F;
+}
+
+/* Button variants by agenda prefix */
+.btn-cbd {
+  color: #fff;
+  background-color: #009B48;
+  border-color: #008a40;
+}
+.btn-cbd:hover, .btn-cbd:focus {
+  background-color: #008a40;
+  border-color: #007838;
+}
+
+.btn-cp {
+  color: #fff;
+  background-color: #A05800;
+  border-color: #8a4c00;
+}
+.btn-cp:hover, .btn-cp:focus {
+  background-color: #8a4c00;
+  border-color: #744000;
+}
+
+.btn-np {
+  color: #fff;
+  background-color: #0086B7;
+  border-color: #0074a0;
+}
+.btn-np:hover, .btn-np:focus {
+  background-color: #0074a0;
+  border-color: #006288;
+}
+
+.btn-sbi {
+  color: #fff;
+  background-color: #5C6BC0;
+  border-color: #4a5ab0;
+}
+.btn-sbi:hover, .btn-sbi:focus {
+  background-color: #4a5ab0;
+  border-color: #3e4e9a;
+}
+
+.btn-sbstta {
+  color: #fff;
+  background-color: #00838F;
+  border-color: #00727c;
+}
+.btn-sbstta:hover, .btn-sbstta:focus {
+  background-color: #00727c;
+  border-color: #006169;
+}

--- a/app/directives/reg-open.html
+++ b/app/directives/reg-open.html
@@ -1,23 +1,29 @@
-﻿<div class="row" ng-show="isRegistrationOpen">
-  <div class="col-lg-6 col-lg-offset-3  col-sm-6 col-xs-12" ng-repeat="meeting in meetings">
+<div ng-show="isRegistrationOpen">
+  <div ng-repeat="group in conferenceGroups">
+    <hr>
+    <h3 class="text-center">{{group.conference.Title.en}}</h3>
+    <div class="row">
+      <div class="col-lg-6 col-sm-6 col-xs-12" ng-repeat="meeting in group.meetings">
 
-    <div class="panel" ng-class="{ 'panel-primary' : m.primary, 'panel-info' : !m.primary }">
-      <div class="panel-heading  text-center text-nowrap">
-        <h4 class="hidden-xs" style="color:inherit;">{{meeting.titleShort || meeting.EVT_CD}}</h4>
-        <h5 class="visible-xs" style="color:inherit;">{{meeting.titleShort || meeting.EVT_CD}}</h5>
-        <div ng-if="!meeting.hideDates" class="text-center">{{meeting.EVT_FROM_DT | date:'yyyy-MM-dd': 'UTC' }}
-          <span> to </span> {{meeting.EVT_TO_DT | date:'yyyy-MM-dd':'UTC' }}
-        </div>
+        <div class="panel" ng-class="meeting.panelClass || 'panel-info'">
+          <div class="panel-heading  text-center text-nowrap">
+            <h4 class="hidden-xs" style="color:inherit;">{{meeting.titleShort || meeting.EVT_CD}}</h4>
+            <h5 class="visible-xs" style="color:inherit;">{{meeting.titleShort || meeting.EVT_CD}}</h5>
+            <div ng-if="!meeting.hideDates" class="text-center">{{meeting.EVT_FROM_DT | date:'yyyy-MM-dd': 'UTC' }}
+              <span> to </span> {{meeting.EVT_TO_DT | date:'yyyy-MM-dd':'UTC' }}
+            </div>
+          </div>
+          <div class="panel-body text-center" >
+            <div class="btn-group-vertical">
+              <a class="btn btn-sm" ng-class="meeting.btnClass || 'btn-info'" ng-href="{{meeting.href}}">Request a Side-event</a>
+            </div>
+          </div>
+          <div class="panel-footer text-right">
+            <div ng-if="!meeting.hideDates" class="text-center">
+              <span > Deadline for this side-event registration is:</span><br> <strong>{{ meeting.end | date:'yyyy-MM-dd HH:mm' }}</strong></div>
+            </div>
+          </div>
       </div>
-      <div class="panel-body text-center" >
-        <div class="btn-group-vertical">
-          <a class="btn btn-sm btn-info" ng-href="{{meeting.href}}">Request a Side-event</a>
-        </div>
-      </div>
-      <div class="panel-footer text-right">
-        <div ng-if="!meeting.hideDates" class="text-center">
-          <span > Deadline for this side-event registration is:</span><br> <strong>{{ meeting.end | date:'yyyy-MM-dd HH:mm' }}</strong></div>
-        </div>
-      </div>
+    </div>
   </div>
 </div>

--- a/app/directives/reg-open.js
+++ b/app/directives/reg-open.js
@@ -80,7 +80,7 @@ function findOpenRegsQuery(){
                   'schedule.sideEvents.start': { $lt: { $date: moment() } },
                   'schedule.sideEvents.end'  : { $gt: { $date: moment() } },
                 },
-            f:  { MajorEventIDs: 1, 'schedule.sideEvents.start': 1, 'schedule.sideEvents.end': 1 , 'schedule.sideEvents.hideDates': 1, 'schedule.sideEvents.excludedMeetings': 1 },
+            f:  { 'Title.en':1, MajorEventIDs: 1, 'schedule.sideEvents.start': 1, 'schedule.sideEvents.end': 1 , 'schedule.sideEvents.hideDates': 1, 'schedule.sideEvents.excludedMeetings': 1 },
             s: { 'schedule.sideEvents.start': 1 }
           }
 }
@@ -90,7 +90,7 @@ function meetingsQuery(meetingIds){
             q:  {
                   '_id': { '$in': meetingIds }
                 },
-            f: { titleShort:1, EVT_CD:1, EVT_TO_DT:1, EVT_FROM_DT:1, EVT_THM_CD:1 },
+            f: { titleShort:1, EVT_CD:1, EVT_TO_DT:1, EVT_FROM_DT:1, EVT_THM_CD:1, 'agenda.prefix':1 },
             s: { EVT_FROM_DT: 1 }
           }
 }
@@ -120,28 +120,48 @@ function loadMeetingsData(conferences){
 }
 
 function setMeetings(res){
-  var meetings = res.data
+  const meetings = res.data
 
-  for (var i = meetings.length-1; i >=0; i--) {
-    var parentConference = getConference(meetings[i]._id)
-console.log('this.$location.host()', this.$location.host())
-console.log('this.$location.host()', this.$location.path())
+  for (let i = meetings.length-1; i >=0; i--) {
+    const parentConference = getConference(meetings[i]._id)
+
+    const prefix   = meetings[i].agenda && meetings[i].agenda.prefix
+    const classKey = prefix && prefix.toUpperCase()
+    const panelMap = { CBD:'panel-cbd', CP:'panel-cp', NP:'panel-np', SBI:'panel-sbi', SBSTTA:'panel-sbstta' }
+    const btnMap   = { CBD:'btn-cbd',   CP:'btn-cp',   NP:'btn-np',   SBI:'btn-sbi',   SBSTTA:'btn-sbstta' }
+    
+    meetings[i].panelClass = panelMap[classKey] || 'panel-info'
+    meetings[i].btnClass   = btnMap[classKey]   || 'btn-info'
 
     const isProd = this.$location.host().includes('cbd.int') && this.$location.path().startsWith('/side-events')
     const base = !isProd? '/side-events' : ''
     const href = `${base}/manage/events/new?meetingId=${meetings[i]._id}`
 
 
-    meetings[i] = this._.assign(meetings[i],{href,start:parentConference.schedule.sideEvents.start,end:parentConference.schedule.sideEvents.end, hideDates: parentConference.schedule.sideEvents.hideDates})
+    meetings[i] = this._.assign(meetings[i],{href,conferenceId:parentConference._id,start:parentConference.schedule.sideEvents.start,end:parentConference.schedule.sideEvents.end, hideDates: parentConference.schedule.sideEvents.hideDates})
   }
   this.$scope.meetings = meetings
+  this.$scope.conferenceGroups = buildConferenceGroups.call(this, meetings)
+}
+
+function buildConferenceGroups(meetings){
+  const groups = []
+
+  for (var i = 0; i < this.$scope.conferences.length; i++) {
+    const conference = this.$scope.conferences[i]
+    const groupMeetings = this._.filter(meetings, { conferenceId: conference._id })
+
+    if(groupMeetings.length) groups.push({ conference: conference, meetings: groupMeetings })
+  }
+
+  return groups
 }
 
 function getConference(meetingId) {
 
   return this._.findLast(this.$scope.conferences,function(c){
 
-      var ids =c.MajorEventIDs 
+      const ids =c.MajorEventIDs 
       for (let i = 0; i < ids.length; i++) 
         if(meetingId === ids[i])
           return true


### PR DESCRIPTION
## DEV-872  - Group Meetings by Conference with Agenda-Prefix Colour Coding

| Category | LOC |
|----------|-----|
| Code     | 185 |
| Tests    | 0 |
| Comments | 2 |

### Changes

- Meetings in the open-registration panel are now grouped under their parent conference heading.
- Each meeting card and button is styled by the meeting's agenda prefix (`CBD`, `CP`, `NP`, `SBI`, `SBSTTA`) using new panel and button CSS variants; defaults to the `info` style when no prefix is present.
- Conferences query now fetches the `Title` field; meetings query fetches `agenda.prefix` to drive the new styling.
- New CSS variants added in `app/css/main.css`.

### Tests

No automated tests — legacy AngularJS project. Verification via the open-registration panel: visual grouping, colour mapping per prefix, and fallback to default style.

### Testability Coverage

| Testable Item | Tested | Link |
|---|---|---|
| Meetings grouped by parent conference | :x: (manual) | [app/directives/reg-open.js](app/directives/reg-open.js) |
| Agenda-prefix to CSS-variant mapping (CBD/CP/NP/SBI/SBSTTA) | :x: (manual) | [app/directives/reg-open.js](app/directives/reg-open.js) |
| Default `info` style fallback when no prefix | :x: (manual) | [app/directives/reg-open.html](app/directives/reg-open.html) |
| Conferences query `Title` field | :x: (manual) | [app/directives/reg-open.js](app/directives/reg-open.js) |
| Meetings query `agenda.prefix` field | :x: (manual) | [app/directives/reg-open.js](app/directives/reg-open.js) |
| New panel/button CSS variants | :x: (manual visual) | [app/css/main.css](app/css/main.css) |

**Summary:** 0 of 6 testable items are covered by automated tests; all rely on manual verification.

### Base

